### PR TITLE
Metrics and logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ deploy: test
 	# Compile
 	GOARCH=amd64 GOOS=linux godep go build -ldflags=$(GOLDFLAGS) -o brigade
 	# Copy binaries
-	@scp $(SSHKEY) brigade $(DEPLOY_HOST):~/
+	@scp brigade $(DEPLOY_HOST):~/
 	# Cleanup binaries
 	@rm brigade
 

--- a/cmd/diff/diff_test.go
+++ b/cmd/diff/diff_test.go
@@ -4,11 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"github.com/Shopify/brigade/cmd/diff"
+	"github.com/Sirupsen/logrus"
 	"github.com/aybabtme/goamz/s3"
 	"github.com/kr/pretty"
 	"io"
-	"log"
-	"os"
 	"sort"
 	"testing"
 )
@@ -63,8 +62,6 @@ func TestCanDiffOldEmptyNewIsNotKeySets(t *testing.T) {
 
 func TestCanDiffWhenOldlistIsCorrupted(t *testing.T) {
 	// setup
-	log.SetOutput(testwriter(t)) // log to testing.Log
-
 	oldKeys := []s3.Key{{ETag: "1"}, {ETag: "3"}}
 	newKeys := []s3.Key{{ETag: "1"}, {ETag: "2"}, {ETag: "3"}}
 	want := []s3.Key{{ETag: "2"}}
@@ -76,7 +73,7 @@ func TestCanDiffWhenOldlistIsCorrupted(t *testing.T) {
 
 	// execute
 	output := bytes.NewBuffer(nil)
-	err := diff.Diff(testlogger(t), oldList, newList, output)
+	err := diff.Diff(oldList, newList, output)
 
 	// verify
 	if err == nil {
@@ -90,8 +87,6 @@ func TestCanDiffWhenOldlistIsCorrupted(t *testing.T) {
 
 func TestCanDiffWhenNewlistIsCorrupted(t *testing.T) {
 	// setup
-	log.SetOutput(testwriter(t)) // log to testing.Log
-
 	oldKeys := []s3.Key{{ETag: "1"}, {ETag: "3"}}
 	newKeys := []s3.Key{{ETag: "1"}, {ETag: "2"}, {ETag: "3"}}
 	want := []s3.Key{{ETag: "2"}}
@@ -103,7 +98,7 @@ func TestCanDiffWhenNewlistIsCorrupted(t *testing.T) {
 
 	// execute
 	output := bytes.NewBuffer(nil)
-	err := diff.Diff(testlogger(t), oldList, newList, output)
+	err := diff.Diff(oldList, newList, output)
 
 	// verify
 	if err == nil {
@@ -118,17 +113,14 @@ func TestCanDiffWhenNewlistIsCorrupted(t *testing.T) {
 // context builders
 
 func testDiff(t *testing.T, oldKeys, newKeys, want []s3.Key) {
-	log.SetOutput(testwriter(t)) // log to testing.Log
-
 	oldList := encodeKeys(oldKeys)
 	newList := encodeKeys(newKeys)
 	testDiffReaders(t, oldList, newList, want)
-
 }
 
 func testDiffReaders(t *testing.T, oldkeys, newkeys io.Reader, want []s3.Key) {
 	output := bytes.NewBuffer(nil)
-	err := diff.Diff(testlogger(t), oldkeys, newkeys, output)
+	err := diff.Diff(oldkeys, newkeys, output)
 	if err != nil {
 		t.Fatalf("failed to diff: %v", err)
 	}
@@ -171,24 +163,6 @@ func lastErrReader(r io.Reader, lastReadErr error) io.Reader {
 	})
 }
 
-// io.Writer implementer
-type writer func(p []byte) (int, error)
-
-func (w writer) Write(p []byte) (int, error) { return w(p) }
-
-// magic, a testing.T writer!
-func testwriter(t *testing.T) io.Writer {
-	return writer(func(p []byte) (int, error) {
-		t.Log(string(p))
-		return 0, nil
-	})
-}
-
-// magic, a testing.T logger!
-func testlogger(t *testing.T) *log.Logger {
-	return log.New(io.MultiWriter(testwriter(t), os.Stderr), "[test]", 0)
-}
-
 // decode s3 keys from a json reader, fatals on error
 func decodeKeys(r io.Reader) []s3.Key {
 	dec := json.NewDecoder(r)
@@ -202,7 +176,7 @@ func decodeKeys(r io.Reader) []s3.Key {
 		case nil:
 			keys = append(keys, key)
 		default:
-			log.Fatalf("decoding buf, %v", err)
+			logrus.WithField("error", err).Fatal("decoding buf")
 		}
 	}
 }
@@ -214,7 +188,7 @@ func encodeKeys(keys []s3.Key) *bytes.Buffer {
 	for _, key := range keys {
 		err := enc.Encode(&key)
 		if err != nil {
-			log.Fatalf("encoding buf, %v", err)
+			logrus.WithField("error", err).Fatal("encoding buf")
 		}
 	}
 	return out

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -5,43 +5,29 @@ import (
 	"encoding/json"
 	"github.com/Shopify/brigade/cmd/list"
 	"github.com/Shopify/brigade/s3mock"
+	"github.com/Sirupsen/logrus"
 	"github.com/aybabtme/goamz/s3"
 	"io"
 	"io/ioutil"
-	"log"
-	"os"
 	"sort"
 	"testing"
 	"time"
 )
 
-func TestCanListBucketWithoutDedup(t *testing.T) {
-	dedup := false
-	elog := testlogger(t)
+func TestCanListBucket(t *testing.T) {
 	withPerfBucket(t, func(t *testing.T, s3 *s3mock.MockS3, bkt s3mock.MockBucket, w io.Writer) error {
-		return list.List(elog, s3.S3(), "s3://"+bkt.Name(), w, dedup)
-	})
-
-}
-
-func TestCanListBucketWithDedup(t *testing.T) {
-	dedup := true
-	elog := testlogger(t)
-	withPerfBucket(t, func(t *testing.T, s3 *s3mock.MockS3, bkt s3mock.MockBucket, w io.Writer) error {
-		return list.List(elog, s3.S3(), "s3://"+bkt.Name(), w, dedup)
+		return list.List(s3.S3(), "s3://"+bkt.Name(), w, true)
 	})
 }
 
 func TestCanHandleS3Errors(t *testing.T) {
-	// mute the standard output
-	log.SetOutput(testwriter(t))
 
 	mockBkt := s3mock.NewPerfBucket(t)
 	mockS3 := s3mock.NewMock(t).Seed(mockBkt)
 
 	// log the output to a buffer
 	errout := bytes.NewBuffer(nil)
-	elog := log.New(errout, "[error] ", 0)
+	logrus.SetOutput(errout)
 	// will sleep for ~1s total, giving a chance to print 1 report
 	list.MaxRetry = 5
 	list.InitRetry = time.Millisecond * 8
@@ -56,7 +42,7 @@ func TestCanHandleS3Errors(t *testing.T) {
 	// - it will be abandoned once
 	wantAbandon := 1
 
-	err := list.List(elog, mockS3.S3(), "s3://"+mockBkt.Name(), ioutil.Discard, true)
+	err := list.List(mockS3.S3(), "s3://"+mockBkt.Name(), ioutil.Discard, true)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -78,7 +64,6 @@ func TestCanHandleS3Errors(t *testing.T) {
 // test context builders
 
 func withPerfBucket(t *testing.T, f func(*testing.T, *s3mock.MockS3, s3mock.MockBucket, io.Writer) error) {
-	log.SetOutput(testwriter(t))
 
 	mockBkt := s3mock.NewPerfBucket(t)
 	mockS3 := s3mock.NewMock(t).Seed(mockBkt)
@@ -108,26 +93,6 @@ func checkKeys(t *testing.T, truth []s3.Key, gotKeybuf io.Reader) {
 	}
 }
 
-// helpers
-
-// io.Writer implementer
-type writer func(p []byte) (int, error)
-
-func (w writer) Write(p []byte) (int, error) { return w(p) }
-
-// magic, a testing.T writer!
-func testwriter(t *testing.T) io.Writer {
-	return writer(func(p []byte) (int, error) {
-		t.Log(string(p))
-		return 0, nil
-	})
-}
-
-// magic, a testing.T logger!
-func testlogger(t *testing.T) *log.Logger {
-	return log.New(io.MultiWriter(testwriter(t), os.Stderr), "[test]", 0)
-}
-
 // decode s3 keys from a json reader, fatals on error
 func decodeKeys(r io.Reader) []s3.Key {
 	dec := json.NewDecoder(r)
@@ -141,7 +106,7 @@ func decodeKeys(r io.Reader) []s3.Key {
 		case nil:
 			keys = append(keys, key)
 		default:
-			log.Fatalf("decoding buf, %v", err)
+			logrus.WithField("error", err).Fatal("decoding buf")
 		}
 	}
 }

--- a/cmd/list/types.go
+++ b/cmd/list/types.go
@@ -1,39 +1,62 @@
 package list
 
 import (
-	"bytes"
-	"fmt"
+	"expvar"
 	"github.com/aybabtme/goamz/s3"
-	"github.com/bmizerany/perks/quantile"
-	"github.com/dustin/go-humanize"
-	"log"
 	"path"
-	"runtime"
-	"sync"
 	"sync/atomic"
 	"time"
 )
 
 // Collections
 
-type lifoJobs struct{ stack []*Job }
+type lifoJobs struct {
+	exp   *expvar.Int
+	stack []*Job
+}
+
+func newLifoJob(exp *expvar.Int) *lifoJobs {
+	return &lifoJobs{exp: exp}
+}
 
 func (l *lifoJobs) IsEmpty() bool { return len(l.stack) == 0 }
 func (l *lifoJobs) Len() int      { return len(l.stack) }
-func (l *lifoJobs) Add(job *Job)  { l.stack = append(l.stack, job) }
 func (l *lifoJobs) Peek() *Job    { return l.stack[len(l.stack)-1] }
+func (l *lifoJobs) Add(job *Job) {
+	l.stack = append(l.stack, job)
+	l.exp.Add(1)
+}
 func (l *lifoJobs) Remove() *Job {
 	item := l.stack[len(l.stack)-1]
 	l.stack = l.stack[:len(l.stack)-1]
+	l.exp.Add(-1)
 	return item
 }
 
-type jobSet map[uint64]struct{}
+type jobSet struct {
+	exp *expvar.Int
+	set map[uint64]struct{}
+}
 
-func (j jobSet) Contains(job *Job) bool { _, ok := j[job.id]; return ok }
-func (j jobSet) IsEmpty() bool          { return len(j) == 0 }
-func (j jobSet) Add(job *Job)           { j[job.id] = struct{}{} }
-func (j jobSet) Delete(job *Job)        { delete(j, job.id) }
+func newSet(exp *expvar.Int) *jobSet {
+	return &jobSet{
+		exp: exp,
+		set: make(map[uint64]struct{}),
+	}
+}
+
+func (j jobSet) Contains(job *Job) bool { _, ok := j.set[job.id]; return ok }
+func (j jobSet) IsEmpty() bool          { return len(j.set) == 0 }
+
+func (j jobSet) Add(job *Job) {
+	j.set[job.id] = struct{}{}
+	j.exp.Add(1)
+}
+
+func (j jobSet) Delete(job *Job) {
+	delete(j.set, job.id)
+	j.exp.Add(-1)
+}
 
 // Job holds the state of visiting an path in S3. This state includes
 // the last error, the number of retries left, the duration of the
@@ -63,68 +86,4 @@ func newJob(rel string) *Job {
 		path:      relpath,
 		// other fields nil-value is correct
 	}
-}
-
-// stats to print the progress of a bucket walk
-type walkStats struct {
-	sync.Mutex
-
-	workToDo  int64
-	followers int64
-
-	newKeys    int64
-	newLeads   int64
-	totalKeys  int64
-	jobsPerSec int64
-	totalSize  uint64
-	mem        runtime.MemStats
-	qtStream   *quantile.Stream
-
-	tick *time.Ticker
-}
-
-func newWalkStats() *walkStats {
-	stats := &walkStats{
-		qtStream: quantile.NewTargeted(0.50, 0.95),
-		tick:     time.NewTicker(time.Second),
-	}
-
-	go func() {
-		for _ = range stats.tick.C {
-			stats.Lock()
-			stats.printProgress()
-			stats.Unlock()
-		}
-	}()
-
-	return stats
-}
-
-func (w *walkStats) Stop() { w.tick.Stop() }
-
-func (w *walkStats) printProgress() {
-	curInflight := atomic.LoadInt64(&inflight)
-
-	runtime.ReadMemStats(&w.mem)
-	p50 := time.Duration(int64(w.qtStream.Query(0.50)))
-	p95 := time.Duration(int64(w.qtStream.Query(0.95)))
-
-	buf := bytes.NewBuffer(nil)
-	_, _ = fmt.Fprintf(buf, "mem=%s\t", humanize.Bytes(w.mem.Sys-w.mem.HeapReleased))
-	_, _ = fmt.Fprintf(buf, "jobs/s=%s\t", humanize.Comma(w.jobsPerSec))
-	_, _ = fmt.Fprintf(buf, "work=%s\t", humanize.Comma(w.workToDo))
-	_, _ = fmt.Fprintf(buf, "follow=%s\t", humanize.Comma(w.followers))
-	_, _ = fmt.Fprintf(buf, "inflight=%s\t", humanize.Comma(curInflight))
-	_, _ = fmt.Fprintf(buf, "keys=%s\t", humanize.Comma(w.totalKeys))
-	_, _ = fmt.Fprintf(buf, "bktsize=%s\t", humanize.Bytes(w.totalSize))
-	_, _ = fmt.Fprintf(buf, "new=%s\t", humanize.Comma(w.newKeys))
-	_, _ = fmt.Fprintf(buf, "leads=%s\t", humanize.Comma(w.newLeads))
-	_, _ = fmt.Fprintf(buf, "p50=%v\t", p50)
-	_, _ = fmt.Fprintf(buf, "p95=%v\t", p95)
-	log.Println(buf.String())
-
-	w.newKeys = 0
-	w.newLeads = 0
-	w.jobsPerSec = 0
-	w.qtStream.Reset()
 }


### PR DESCRIPTION
This is mostly a cosmetic PR, it changes the logger to use `logrus` exported funcs. It also uses `expvar` for metrics, which the [upcoming Datadog agent (v5.0)](https://github.com/DataDog/dd-agent/blob/73dd75035f1982d31818bb8a4a2a6cc856cf8bb7/CHANGELOG.md#500--unreleased) will plug into out of the box.

@fbogsany 
