### PR TITLE
Remove dedup flag, correctness requires to always deduplicate.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -44,7 +44,6 @@ func listCommand(auth aws.Auth) cli.Command {
 		bucketFlag = cli.StringFlag{Name: "bucket", Value: "", Usage: "path to bucket to list, of the form s3://name/path/"}
 		dstFlag    = cli.StringFlag{Name: "dest", Value: "bucket_list.json.gz", Usage: "filename to which the list of keys is saved"}
 		regionFlag = cli.StringFlag{Name: "aws-region", Value: aws.USEast.Name, Usage: "AWS region where the bucket lives"}
-		dedupFlag  = cli.BoolFlag{Name: "dedup", Usage: "deduplicate jobs and keys, consumes much more memory"}
 	)
 
 	return cli.Command{
@@ -53,13 +52,12 @@ func listCommand(auth aws.Auth) cli.Command {
 		Description: strings.TrimSpace(`
 Do a traversal of the S3 bucket using many concurrent workers. The result of
 traversing is saved and gzip'd as a list of s3 keys in JSON form.`),
-		Flags: []cli.Flag{bucketFlag, dstFlag, regionFlag, dedupFlag},
+		Flags: []cli.Flag{bucketFlag, dstFlag, regionFlag},
 		Action: func(c *cli.Context) {
 
 			bucket := c.String(bucketFlag.Name)
 			dest := c.String(dstFlag.Name)
 			regionName := c.String(regionFlag.Name)
-			dedup := c.Bool(dedupFlag.Name)
 
 			region, validRegion := aws.Regions[regionName]
 
@@ -93,7 +91,7 @@ traversing is saved and gzip'd as a list of s3 keys in JSON form.`),
 
 			logrus.Info("starting command", c.Command.Name)
 
-			err := list.List(s3.New(auth, region), bucket, gw, dedup)
+			err := list.List(s3.New(auth, region), bucket, gw)
 			if err != nil {
 				logrus.WithField("error", err).Error("failed to list bucket")
 			}

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestCanListBucket(t *testing.T) {
 	withPerfBucket(t, func(t *testing.T, s3 *s3mock.MockS3, bkt s3mock.MockBucket, w io.Writer) error {
-		return list.List(s3.S3(), "s3://"+bkt.Name(), w, true)
+		return list.List(s3.S3(), "s3://"+bkt.Name(), w)
 	})
 }
 
@@ -42,7 +42,7 @@ func TestCanHandleS3Errors(t *testing.T) {
 	// - it will be abandoned once
 	wantAbandon := 1
 
-	err := list.List(mockS3.S3(), "s3://"+mockBkt.Name(), ioutil.Discard, true)
+	err := list.List(mockS3.S3(), "s3://"+mockBkt.Name(), ioutil.Discard)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}


### PR DESCRIPTION
Remove the dedup flag, since the `list` command should always deduplicate edges while traversing the graph of our S3 bucket. The bucket must be seen as a graph because concurrent activity can lead to many calls to `s3.List` returning the same paths.

r: @shuhaowu , @camilo 
