### PR TITLE
fetch last source to a file, then use that file for diff

### DIFF
--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dustin/go-humanize"
 	"io"
 	"io/ioutil"
-	"net"
 	"os"
 	"path"
 	"strings"

--- a/cmd/backup/backup_test.go
+++ b/cmd/backup/backup_test.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"bytes"
+	"errors"
 	"github.com/Shopify/brigade/s3mock"
 	"github.com/Sirupsen/logrus"
 	"github.com/aybabtme/goamz/s3"
@@ -173,6 +174,9 @@ func (b *byteSeeker) Close() error                { return nil }
 
 // only ever resets the buffer to offset 0
 func (b *byteSeeker) Seek(offset int64, whence int) (int64, error) {
+	if offset != 0 || whence != 0 {
+		return -1, errors.New("can only invoke byteSeeker.Seek with 0 offset, 0 whence")
+	}
 	b.buf = bytes.NewBuffer(b.buf.Bytes())
 	return 0, nil
 }


### PR DESCRIPTION
Before doing a sync on all the keys, we try to fetch from S3 the last key listing that was sync'd.

The current code uses the `io.Reader` straight from S3 to do the comparison with the current listing. In practice, this stream is large (>1GB) and errors out in the process, leading to failure of the diff and resulting in a full list sync, which is orders of magnitude slower than an incremental sync.

This PR will instead fetch the whole object to a temporary file, then use that file to do the diff.

r: @camilo @fbogsany @shuhaowu 
cc: @Shopify/webscale 
